### PR TITLE
Facebook Registertion Control From ACP

### DIFF
--- a/myfbconnect.php
+++ b/myfbconnect.php
@@ -19,6 +19,7 @@ define('ALLOWABLE_PAGE', 'fblogin,fbregister,do_fblogin');
 require_once "./global.php";
 
 $lang->load('myfbconnect');
+$lang->load("member");
 
 if (!$mybb->settings['myfbconnect_enabled']) {
 	header("Location: index.php");
@@ -82,6 +83,10 @@ if ($mybb->input['action'] == "do_fblogin") {
 	catch (FacebookApiException $e) {
 		error($lang->sprintf($lang->myfbconnect_error_report, $e->getMessage()));
 	}
+		if($mybb->settings['disableregs'] == 1)
+	{
+		error($lang->registrations_disabled);
+     }
 }
 
 // don't stop the magic, again!


### PR DESCRIPTION
added the permissions to disallow users to register if reregistration is closed from ACP but already registered users with Facebook can keep logging normally
- added Language for the error
