### PR TITLE
Addressed a warning thrown because 2nd argument was missing (will be aut...

### DIFF
--- a/inc/plugins/MyFacebookConnect/class_facebook.php
+++ b/inc/plugins/MyFacebookConnect/class_facebook.php
@@ -496,7 +496,7 @@ class MyFacebook
 	/**
 	 * Synchronizes Facebook's data with MyBB's data
 	 */
-	public function sync($user, $data)
+	public function sync($user, $data = '')
 	{
 		if (!$user['uid']) {
 			return false;


### PR DESCRIPTION
...omatically handled internally)
