### PR TITLE
fix facebook profile picture fetching

### DIFF
--- a/inc/plugins/MyFacebookConnect/class_facebook.php
+++ b/inc/plugins/MyFacebookConnect/class_facebook.php
@@ -533,8 +533,12 @@ class MyFacebook
 		if ($user['fbavatar'] and $data['id'] and $mybb->settings['myfbconnect_fbavatar']) {
 			
 			list($maxwidth, $maxheight) = explode('x', my_strtolower($mybb->settings['maxavatardims']));
-			
-			$update["avatar"]     = $db->escape_string("http://graph.facebook.com/{$data['id']}/picture?width={$maxwidth}&height={$maxheight}");
+			// getting the actual picture URL, which is what we need to display the avatar
+			$json_content = file_get_contents("http://graph.facebook.com/{$data['id']}/picture?redirect=0&width={$maxwidth}&height={$maxheight}");
+                        $json_obj = json_decode($json_content);
+                        $update["avatar"]     = $db->escape_string($json_obj->data->url);
+			// this commented line instead was storing the URL responsible for redirecting to the picture
+			//$update["avatar"]     = $db->escape_string("http://graph.facebook.com/{$data['id']}/picture?width={$maxwidth}&height={$maxheight}");
 			$update["avatartype"] = "remote";
 			
 			// Copy the avatar to the local server (work around remote URL access disabled for getimagesize)


### PR DESCRIPTION
Getting and storing in db the actual URL for a facebook profile picture instead of the URL redirecting to it.
*\* I also had to change the avatar field lenght in mybb_users table from 200 chars to 255 chars otherwise the URL will not fit in. **
